### PR TITLE
Restructuring library to fix issues.

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -32,11 +32,13 @@
 (defpackage :thread-pool
   (:use :cl)
   (:export #:make-thread-pool
-	   #:start-pool
-	   #:stop-pool
-	   #:add-to-pool
-	   #:pool-size
-	   #:callable
-	   #:callable-call
-	   #:callable-handler-func)
+       #:start-pool
+       #:stop-pool
+       #:add-to-pool
+       #:pool-size
+       #:callable
+       #:callable-call
+       #:callable-handler-func
+       #:with-thread-pool
+       #:wait-pool-empty)
   (:documentation "A simple thread pool system"))

--- a/src/thread-pool.lisp
+++ b/src/thread-pool.lisp
@@ -43,15 +43,23 @@
   (:documentation "Stops serving jobs"))
 (defgeneric add-to-pool (thread-pool functions)
   (:documentation "Add a function or a list of function to the thread pool"))
+(defgeneric wait-pool-empty (thread-pool &key timeout)
+  (:documentation "Wait until all submitted jobs are finished."))
+
+(defclass thread ()
+  ((thread :initarg :thread :accessor thread)
+   (running-p :initform nil :accessor running-p)
+   (job :initform nil :accessor job)
+   (lock :initarg :lock :reader lock)
+   (condition :initarg :condition :reader th-condition)))
 
 (defclass thread-pool ()
   ((jobs :accessor jobs :initform (make-instance 'arnesi:queue))
    (pool-size :reader pool-size :initarg :pool-size)
    (threads :accessor threads :initform ())
-   (thread-locks :accessor thread-locks :initform ())
-   (pool-condition-vars :accessor pool-condition-vars :initform ())
-   (pool-lock :accessor pool-lock :initform (bordeaux-threads:make-lock))
-   (pool-condition :accessor pool-condition :initform (bordeaux-threads:make-condition-variable))
+   (pool-lock :accessor pool-lock :initform (bt:make-lock))
+   (pool-condition :accessor pool-condition :initform (bt:make-condition-variable))
+   (empty-condition :accessor empty-condition :initform (bt:make-condition-variable))
    (running-p :accessor running-p :initform nil)
    (main-thread :accessor main-thread :initform nil))
   (:default-initargs :pool-size 1))
@@ -63,99 +71,135 @@
 (defun make-thread-pool (&optional (pool-size 1))
   (make-instance 'thread-pool :pool-size pool-size))
 
+(defun make-pool-thread (thread-pool)
+  (let ((thread (make-instance 'thread
+                               :lock (bt:make-lock)
+                               :condition (bt:make-condition-variable))))
+    (setf (thread thread)
+          (bt:make-thread
+           (lambda ()
+             (loop while (bt:with-lock-held ((pool-lock thread-pool))
+                           (running-p thread-pool))
+                do (bt:with-lock-held ((lock thread))
+                     (bt:condition-wait (th-condition thread) (lock thread))
+                     (with-accessors ((pool-lock pool-lock)
+                                      (pool-condition pool-condition))
+                         thread-pool
+
+                       (let ((func (job thread)))
+                         (when func
+                           (setf (job thread) nil)
+                           (if (typep func 'callable)
+                               (callable-call func)
+                               (funcall func))
+                           (bt:with-lock-held (pool-lock)
+                             (bt:condition-notify pool-condition))))))))
+           :name "THREAD-POOL:WORKER-THREAD"))
+    thread))
+
+(defun make-main-thread (thread-pool)
+  (with-accessors ((pool-condition pool-condition)
+                   (empty-condition empty-condition)
+                   (threads threads)
+                   (running-p running-p)
+                   (pool-lock pool-lock)
+                   (jobs jobs))
+      thread-pool
+    (bt:make-thread
+     (lambda ()
+       (bt:with-lock-held (pool-lock)
+         (loop
+            while running-p
+            do (bt:condition-wait pool-condition pool-lock)
+               (if (> (arnesi:queue-count jobs) 0)
+                   (loop
+                      for thr in threads
+                      when (bt:acquire-lock (lock thr) nil)
+                      do (let ((job (arnesi:dequeue jobs)))
+                           (when job
+                             (setf (job thr) job)
+                             (bt:condition-notify (th-condition thr))))
+                        (bt:release-lock (lock thr)))
+                   (bt:condition-notify empty-condition)))))
+     :name "THREAD-POOL:MAIN-THREAD")))
+
 (defmethod start-pool ((thread-pool thread-pool))
-  (with-accessors ((pool-condition pool-condition)		   
-		   (main-thread main-thread)
-		   (threads threads)
-		   (thread-locks thread-locks)
-		   (pool-size pool-size)
-		   (running-p running-p)
-		   (pool-lock pool-lock)
-		   (pool-condition-vars pool-condition-vars)
-		   (jobs jobs))
+  (with-accessors ((main-thread main-thread)
+                   (threads threads)
+                   (pool-size pool-size)
+                   (running-p running-p))
       thread-pool
     (unless running-p
       (setf running-p t
-	    main-thread (let ((lock pool-lock))
-			  (let ((thread (bordeaux-threads:make-thread 
-					 (lambda ()
-					   (bordeaux-threads:with-lock-held (lock)
-					     (loop
-						while (running-p thread-pool)
-						do (progn (bordeaux-threads:condition-wait pool-condition lock)
-							  (with-accessors ((threads threads)
-									   (pool-condition-vars pool-condition-vars)
-									   (jobs jobs))
-							      thread-pool
-							    (when jobs					      
-							      (loop for thr in threads
-								 for thr-cond in pool-condition-vars
-								 for thr-lock in thread-locks
-								 when (and thr (bordeaux-threads:acquire-lock thr-lock nil))
-								 return (progn (bordeaux-threads:condition-notify thr-cond) 
-									       (bordeaux-threads:release-lock thr-lock))))))))))))
-			    (bordeaux-threads:with-lock-held (lock)
-			      (bordeaux-threads:condition-notify pool-condition))
-			    thread))
-
-	    pool-condition-vars (loop for i from 1 to pool-size
-				   collect (bordeaux-threads:make-condition-variable))
-
-	    thread-locks (loop for i from 1 to pool-size
-			    collect (bordeaux-threads:make-lock))
-
-	    threads (loop for i from 1 to pool-size
-		       collect (let* ((ix (- i 1))
-				      (lock (nth ix thread-locks))
-				      (condition (nth ix pool-condition-vars)))
-				 (bordeaux-threads:make-thread 
-				  (lambda ()				    
-				    (loop 
-					 while running-p
-					 do (bordeaux-threads:with-lock-held (lock)
-					      (progn (bordeaux-threads:condition-wait condition lock)
-						     (with-accessors ((pool-lock pool-lock)
-								      (threads threads)
-								      (jbos jobs)
-								      (pool-condition pool-condition))
-							 thread-pool
-						       
-						       (let ((th (bordeaux-threads:current-thread))
-							     (func nil))
-							 (bordeaux-threads:with-lock-held (pool-lock)
-							   (setf (nth ix threads) nil
-								 func (arnesi:dequeue jobs)))       
-							 (when func
-							   (if (typep func 'callable)
-							       (callable-call func)
-							       (funcall func)))
-							 (bordeaux-threads:with-lock-held (pool-lock)
-							   (setf (nth ix threads) th)))))))
-				    (bordeaux-threads:condition-notify condition)))))))))
+            main-thread (make-main-thread thread-pool)
+            threads (loop for i from 0 below pool-size
+                       collect (make-pool-thread thread-pool))))))
 
 (defmethod stop-pool ((thread-pool thread-pool))
+  #.(format nil "STOP-POOL begins the process of stopping a~@
+                 thread pool. It shuts down the main dispatch~@
+                 thread, and then progressively shuts down the~@
+                 worker threads. If there are workers in the~@
+                 middle of running a job, this will wait for~@
+                 those threads to finish their jobs before~@
+                 shutting them down.")
   (with-accessors ((threads threads)
-		   (pool-size pool-size)
-		   (running-p running-p)
-		   (pool-lock pool-lock)
-		   (pool-condition-vars pool-condition-vars)
-		   (main-thread main-thread))
+                   (pool-size pool-size)
+                   (running-p running-p)
+                   (pool-lock pool-lock)
+                   (pool-condition pool-condition)
+                   (main-thread main-thread))
       thread-pool
     (setf running-p nil)
-    (bordeaux-threads:with-lock-held (pool-lock)
-      (setf main-thread nil
-	    threads nil
-	    pool-condition-vars nil))))
+    (bt:with-lock-held (pool-lock)
+      (bt:condition-notify pool-condition))
+    (loop for thr in threads
+          do (bt:with-lock-held ((lock thr))
+               (bt:condition-notify (th-condition thr))))))
 
 (defmethod add-to-pool ((thread-pool thread-pool) functions)
+  #.(format nil "ADD-TO-POOL adds one or more jobs to a~@
+                 thread pool's queue. These jobs are~@
+                 dispatched to worker threads in the~@
+                 order that they are submitted, as worker~@
+                 threads become available.")
   (with-accessors ((jobs jobs)
-		   (pool-lock pool-lock)
-		   (pool-condition pool-condition))
+           (pool-lock pool-lock)
+           (pool-condition pool-condition))
       thread-pool
-    
-    (bordeaux-threads:with-lock-held (pool-lock)
+
+    (bt:with-lock-held (pool-lock)
       (if (listp functions)
-	  (dolist (func functions)
-	    (arnesi:enqueue jobs func)) 
-	  (arnesi:enqueue jobs functions))
-      (bordeaux-threads:condition-notify pool-condition))))
+          (dolist (func functions)
+            (arnesi:enqueue jobs func))
+          (arnesi:enqueue jobs functions))
+      (bt:condition-notify pool-condition))))
+
+(defmacro with-thread-pool ((pool-name &key (pool-size 1) (wait-pool-empty t)) &rest body)
+  #.(format nil "WITH-THREAD-POOL creates and starts a thread pool,~@
+                 ensuring that it is properly shut down with STOP-POOL~@
+                 when the form returns.~@
+                 ~@
+                 By default, the macro waits until all submitted jobs~@
+                 finish with WAIT-POOL-EMPTY before the form will return.~@
+                 If WAIT-POOL-EMPTY is nil, the macro will call STOP-POOL~@
+                 immediately after the body is executed.~@
+                 See STOP-POOL for a description of its behavior, as it may~@
+                 not stop the pool immediately.")
+  `(let ((,pool-name (make-thread-pool ,pool-size)))
+     (start-pool ,pool-name)
+     (unwind-protect
+          (progn
+            ,@body
+            (when ,wait-pool-empty
+              (wait-pool-empty ,pool-name)))
+       (stop-pool ,pool-name))))
+
+(defmethod wait-pool-empty (thread-pool &key timeout)
+  #.(format nil "WAIT-POOL-EMPTY blocks until all jobs submitted to a~@
+                 thread pool have finished, or until TIMEOUT, if~@
+                 specified.")
+  (with-accessors ((pool-lock pool-lock))
+      thread-pool
+    (bt:with-lock-held (pool-lock)
+      (bt:condition-wait (empty-condition thread-pool) pool-lock :timeout timeout))))


### PR DESCRIPTION
I've found several issues with this library, that I think this PR addresses.
First and probably worst, is that the thread pool doesn't appear to dispatch jobs correctly.
If I submit multiple jobs at once, and the pool isn't big enough to run them all, they get stuck in the queue.
```
CL-USER> (defvar *thread-pool* (thread-pool:make-thread-pool))
                                                                                                                                                                                                     
*THREAD-POOL*
CL-USER> (thread-pool:start-pool *thread-pool*)
NIL 
CL-USER> (let ((stdout *standard-output*))                                                                                                                                                           
           (thread-pool:add-to-pool *thread-pool*                                                                                                                                                    
                                    (list                                                                                                                                                            
                                     (lambda () (format stdout "1"))                                                                                                                                 
                                     (lambda () (format stdout "2"))                                                                                                                                 
                                     (lambda () (format stdout "3"))                                                                                                                                 
                                     (lambda () (format stdout "4"))                                                                                                                                 
                                     (lambda () (format stdout "5"))                                                                                                                                 
                                     (lambda () (format stdout "6")))))                                                                                                                                                                                                  
1
CL-USER>
```

The expected output for the last form is:
```
123456
```

The second issue is brought up in #2. This PR also fixes that issue, causing `STOP-POOL` to gracefully shut down the main dispatch thread as well as the worker threads.

I have also added documentation and two exported symbols, one a macro and the other a generic function:
* `WITH-THREAD-POOL`: Macro to create and start a thread pool which the body has access to. The thread pool will be properly shut down when the form exits, and the caller has the option to specify whether to wait for all submitted jobs to complete or not.
* `WAIT-POOL-EMPTY`: Causes the calling thread to block until all jobs submitted to the thread have completed.
